### PR TITLE
Fixing broken mapbox layer on ArcGIS demo page

### DIFF
--- a/demos/arcgis-server/index.html
+++ b/demos/arcgis-server/index.html
@@ -385,10 +385,10 @@
                     zoom: 6,
                     minZoom: 4,
                     layers: [
-                        new L.TileLayer("http://{s}.tiles.mapbox.com/v3/mapbox.mapbox-light/{z}/{x}/{y}.png", {
-                            subdomains: ["a", "b", "c", "d"],
+                        new L.TileLayer("http://{s}.mqcdn.com/tiles/1.0.0/osm/{z}/{x}/{y}.png", {
+                            subdomains: ["otile1", "otile2", "otile3", "otile4"],
                             maxZoom: 10,
-                            attribution: 'Tiles Courtesy of <a href="http://mapbox.com" target="_blank">MapBox</a>. Map data (c) <a href="http://www.openstreetmap.org/" target="_blank">OpenStreetMap</a> contributors, CC-BY-SA.'
+                            attribution: 'Tiles Courtesy of <a href="http://www.mapquest.com/" target="_blank">MapQuest</a>. Map data (c) <a href="http://www.openstreetmap.org/" target="_blank">OpenStreetMap</a> contributors, CC-BY-SA.'
                         })
                     ]
                 });


### PR DESCRIPTION
The tilelayer for the Senior citizens example on the ArcGIS demo was 404ing.I guess they dropped it? Switched it over to the mapquest tiles used in the other examples.
