### PR TITLE
Fixing Layer off button for GitSpatial Utility poles Demo

### DIFF
--- a/demos/gitspatial/index.html
+++ b/demos/gitspatial/index.html
@@ -218,7 +218,7 @@
                     <div class="span10 height-controlled">
                         <div id="map-container-3" class="map"></div>
                         <div class="layer-buttons">
-                            <div class="row layer-button-row"><a href="javascript:gitspatial_utility_poles.setMap(map3);" class="btn success">Layer On</a> <a href="javascript:gitspatial_neighborhoods.setMap(null);" class="btn danger">Layer Off</a></div>
+                            <div class="row layer-button-row"><a href="javascript:gitspatial_utility_poles.setMap(map3);" class="btn success">Layer On</a> <a href="javascript:gitspatial_utility_poles.setMap(null);" class="btn danger">Layer Off</a></div>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
It was set to affect the neighborhoods example instead.
